### PR TITLE
Various fix

### DIFF
--- a/addon/synthDrivers/newfon/languages/en.py
+++ b/addon/synthDrivers/newfon/languages/en.py
@@ -81,14 +81,17 @@ pseudoEnglishPronunciation = {
 	'j': "дж",
 }
 
+
 re_englishLetters = re.compile(r"\b([a-zA-Z])\b")
 re_stress = re.compile("([аеёиоуыэюяіѣѵ])́", re.U|re.I)
+re_dash = re.compile(r"(\w)-(\w)")
 
 def subEnglishLetters(match):
 	letter = match.group(1).lower()
 	return letters[letter]
 
 def preprocessText(text):
+	text = re_dash.sub(r"\1 - \2", text)
 	englishPronunciation = pseudoEnglishPronunciation if options.get("pseudoEnglishPronunciation") == True else pronunciation
 	text = re_englishLetters.sub(subEnglishLetters, text)
 	for s in englishPronunciation:


### PR DESCRIPTION
In NVDA 2023.1, the behavior of the dash symbol has changed. This especially affected the pronunciation of the English text, where several words were written with dashes.
The accent dictionary was replaced by the dictionary from Igor Poretsky - commit 67479e859cd5955072dc5bbae8065c4417af52cc:
https://github.com/poretsky/rulex
The old dictionary contained a lot of mistakes. And despite the fact that the old dictionary covered more word forms, but the number of errors is not justified.
